### PR TITLE
chore: infer React context providers and prefer use

### DIFF
--- a/src/providers/HeaderTheme/index.tsx
+++ b/src/providers/HeaderTheme/index.tsx
@@ -2,7 +2,7 @@
 
 import type { Theme } from "~/providers/Theme/types";
 
-import React, { createContext, useCallback, useContext, useState } from "react";
+import React, { createContext, useCallback, use, useState } from "react";
 
 import canUseDOM from "~/utilities/canUseDOM";
 
@@ -34,10 +34,10 @@ export const HeaderThemeProvider = ({
   }, []);
 
   return (
-    <HeaderThemeContext.Provider value={{ headerTheme, setHeaderTheme }}>
+    <HeaderThemeContext value={{ headerTheme, setHeaderTheme }}>
       {children}
-    </HeaderThemeContext.Provider>
+    </HeaderThemeContext>
   );
 };
 
-export const useHeaderTheme = (): ContextType => useContext(HeaderThemeContext);
+export const useHeaderTheme = (): ContextType => use(HeaderThemeContext);

--- a/src/providers/Theme/index.tsx
+++ b/src/providers/Theme/index.tsx
@@ -3,7 +3,7 @@
 import React, {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useState,
 } from "react";
@@ -66,11 +66,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     setThemeState(themeToSet);
   }, []);
 
-  return (
-    <ThemeContext.Provider value={{ setTheme, theme }}>
-      {children}
-    </ThemeContext.Provider>
-  );
+  return <ThemeContext value={{ setTheme, theme }}>{children}</ThemeContext>;
 };
 
-export const useTheme = (): ThemeContextType => useContext(ThemeContext);
+export const useTheme = (): ThemeContextType => use(ThemeContext);


### PR DESCRIPTION
* https://github.com/payloadcms/payload/pull/11669
* As of [React 19](https://react.dev/blog/2024/12/05/react-19), context providers no longer require the `<MyContext.Provider>` syntax and can be rendered as `<MyContext>` directly. This will be deprecated in future versions of React, which is now being caught by the [`@eslint-react/no-context-provider`](https://eslint-react.xyz/docs/rules/no-context-provider) ESLint rule.
* Similarly, the [`use`](https://react.dev/reference/react/use) API is now preferred over `useContext` because it is more flexible, for example they can be called within loops and conditional statements. See the [`@eslint-react/no-use-context`](https://eslint-react.xyz/docs/rules/no-use-context) ESLint rule for more details.