### PR TITLE
fix(picture): add classes for picture tag in media component

### DIFF
--- a/src/components/Media/ImageMedia/index.tsx
+++ b/src/components/Media/ImageMedia/index.tsx
@@ -19,6 +19,7 @@ export const ImageMedia: FunctionComponent<MediaProps> = (props) => {
     alt: altFromProps,
     fill,
     imgClassName,
+    pictureClassName,
     priority,
     resource,
     size: sizeFromProps,
@@ -58,7 +59,7 @@ export const ImageMedia: FunctionComponent<MediaProps> = (props) => {
         .join(", ");
 
   return (
-    <picture>
+    <picture className={cn(pictureClassName)}>
       <NextImage
         alt={alt || ""}
         className={cn(imgClassName)}

--- a/src/components/Media/types.ts
+++ b/src/components/Media/types.ts
@@ -11,6 +11,7 @@ export interface Props {
   onClick?: () => void;
   onLoad?: () => void;
   loading?: "lazy" | "eager"; // for NextImage only
+  pictureClassName?: string;
   priority?: boolean; // for NextImage only
   ref?: Ref<HTMLImageElement | HTMLVideoElement | null>;
   resource?: MediaType | string | number | null; // for Payload media


### PR DESCRIPTION
* https://github.com/payloadcms/payload/pull/11605

Sometimes I need to add some classes to the `picture` tag of Media component. in this case I need to do this:
```
<Media
    resource={content.image}
    className="w-full h-full [&>picture]:w-full"  // <<< follow this
    imgClassName="w-full h-full object-cover"
/>
```

So I added an additional props `pictureClassName` for the picture tag. Now I can do this:
```
<Media
    resource={content.image}
    className="w-full h-full"
    pictureClassName="w-full h-full" // <<< follow this
    imgClassName="w-full h-full object-cover"
/>
```
NOTE: I've encountered situations where I needed to add classes to the `picture` tag, not just for `w-full h-full`. To handle this, I had to update the Media component. I believe this would be a valuable improvement to the Media component.